### PR TITLE
fix: disable thinking output in Ollama API requests

### DIFF
--- a/cairn/llm/ollama.py
+++ b/cairn/llm/ollama.py
@@ -27,6 +27,7 @@ class OllamaLLM(LLMInterface):
             "model": self.model,
             "messages": messages,
             "stream": False,
+            "think": False,
             "options": {"num_predict": max_tokens, "temperature": 0.3},
         }).encode()
 


### PR DESCRIPTION
## Summary

- Add `"think": False` to the Ollama `generate()` payload to prevent thinking-capable models (e.g. Qwen3, DeepSeek R1) from emitting chain-of-thought tokens
- Without this, thinking tokens corrupt cairn's structured LLM responses (query expansion, relationship extraction, etc.)
- Non-thinking models silently ignore this parameter, so it is universally safe

## Test plan

- [x] Verify structured responses (query expansion, relationship extraction) work correctly with a thinking-capable model (e.g. Qwen3)
- [x] Verify non-thinking models continue to work as before
- [x] Confirm no regressions in existing LLM-dependent functionality

Tested locally with `qwen3:8b` — search (semantic + hybrid), query expansion, and API status all return clean responses with no thinking token leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)